### PR TITLE
Create projects/scans with appropriate visibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Sample_Source/
 Shell_Script_work/
 Verizon_background_files/
 Zip_Files_Archive/
+*.pyc

--- a/CxRestAPIProjectCreationBase1.py
+++ b/CxRestAPIProjectCreationBase1.py
@@ -1178,7 +1178,7 @@ class CxRestAPIProjectCreationBase:
             CxRestAPIStatistics1.cRestAPICallsMade += 1;
 
             cxRequestURL = "%s/cxrestapi/projects" % (self.cxServerEndpoint.getCxServerURL());
-            cxReqPayload = "{'name':\"%s\", 'owningTeam':\"%s\", 'isPublic':%s}" % (cxProjectCreation.getCxProjectName(), cxProjectCreation.getCxProjectTeamId(), ("true" if (cxProjectCreation.getCxProjectIsPublic() == True) else "false"));
+            cxReqPayload = "{'name':\"%s\", 'owningTeam':\"%s\", 'isPublic':%s}" % (cxProjectCreation.getCxProjectName(), cxProjectCreation.getCxProjectTeamId(), ("true" if (cxProjectCreation.getCxProjectIsPublic().lower() == "true") else "false"));
             cxReqHeaders = {
                 'Content-Type':  "application/json;v=2.0",
                 'Authorization': ("%s %s" % (self.cxServerEndpoint.getCxTokenType(), self.cxServerEndpoint.getCxAccessToken())),

--- a/CxRestAPIProjectCreationBase1.py
+++ b/CxRestAPIProjectCreationBase1.py
@@ -2002,7 +2002,7 @@ class CxRestAPIProjectCreationBase:
             CxRestAPIStatistics1.cRestAPICallsMade += 1;
 
             cxRequestURL = "%s/cxrestapi/sast/scans" % (self.cxServerEndpoint.getCxServerURL());
-            cxReqPayload = "{'projectId':\"%s\", 'isIncremental':\"false\", 'isPublic':\"%s\", 'forceScan':\"true\"}" % (cxProjectCreation.getCxProjectId(), ("true" if (cxProjectCreation.getCxProjectScanIsPublic() == True) else "false"));
+            cxReqPayload = "{'projectId':\"%s\", 'isIncremental':\"false\", 'isPublic':\"%s\", 'forceScan':\"true\"}" % (cxProjectCreation.getCxProjectId(), ("true" if (cxProjectCreation.getCxProjectScanIsPublic().lower() == "true") else "false"));
             cxReqHeaders = {
                 'Content-Type':  "application/json;v=1.0",
                 'Authorization': ("%s %s" % (self.cxServerEndpoint.getCxTokenType(), self.cxServerEndpoint.getCxAccessToken())),


### PR DESCRIPTION
This PR resolves an issue where projects or scans are being created as private even when marked as public=true in the plist. This resolves https://github.com/cxdcox/CxPythonTools/issues/4.

It also adds an ignore for compiled python files.