### PR TITLE
Autocreate/clear working scan dir

### DIFF
--- a/CxApplicationScanner1.py
+++ b/CxApplicationScanner1.py
@@ -198,6 +198,16 @@ def main():
 
         sScriptAppWorkDirspec = os.path.realpath(sScriptAppWorkDir);
 
+        if not os.path.exists(sScriptAppWorkDirspec):
+
+            if bVerbose == True:
+
+                print("");
+                print("%s Creating working directory [%s]..." % (sScriptDisp, sScriptAppWorkDirspec));
+                print("");
+
+            os.makedirs(sScriptAppWorkDirspec);
+
         if not os.path.isdir(sScriptAppWorkDirspec):
 
             print("");

--- a/CxApplicationScannerGITZipper1.py
+++ b/CxApplicationScannerGITZipper1.py
@@ -8,6 +8,7 @@ import sys;
 import collections;
 import zope.interface;
 import subprocess;
+import shutil;
 
 import CxProjectCreation1;
 
@@ -221,6 +222,22 @@ class CxApplicationScannerGITZipper(object):
 
             self.sCxApplicationWorkDir = None;
 
+    def clearApplicationWorkDir(self):
+
+        print("%s Clearing application work dir [%s]" % (self.sClassDisp, self.sCxApplicationWorkDir));
+
+        for filename in os.listdir(self.sCxApplicationWorkDir):
+            file_path = os.path.join(self.sCxApplicationWorkDir, filename);
+            if self.bTraceFlag == True:
+                print("   Deleting %s" % (file_path));
+            try:
+                if os.path.isfile(file_path) or os.path.islink(file_path):
+                    os.unlink(file_path)
+                elif os.path.isdir(file_path):
+                    shutil.rmtree(file_path)
+            except Exception as e:
+                print('Failed to delete %s. Reason: %s' % (file_path, e))
+
     def getCxApplicationZip(self):
 
         return self.sCxApplicationZip;
@@ -374,6 +391,8 @@ class CxApplicationScannerGITZipper(object):
             print("");
 
             return False;
+
+        self.clearApplicationWorkDir();
 
         bProcessingError = False;
 


### PR DESCRIPTION
This PR adds the following changes for scan output dir (argument `-w` or `--app-work-dir` for APP_WORK_DIR):
1. Automatically create directory if it does not exist.
2. Automatically clear (empty) directory prior to retrieving source code and zipping. This allows for multiple runs to execute without needing an external process to reset the directory.
