### PR TITLE
Scan existing local repo (instead of cloning from git)

### DIFF
--- a/CxApplicationScanner1.py
+++ b/CxApplicationScanner1.py
@@ -58,8 +58,8 @@ def main():
         optParser.add_option("--pswd", dest="cx_auth_pswd", default="", help="Checkmarx Authentication Password", metavar="Checkmarx-Password");
         optParser.add_option("-o", "--output-scanner-file", dest="output_scanner_file", default="", help="(Output) Scanner 'report' file [generated]");
         optParser.add_option("-w", "--app-work-dir", dest="app_work_dir", default="", help="Application 'work' directory [generated to - MUST be Empty]");
-        optParser.add_option("--git-user", dest="git_user", default="", help="Git (authentication) UserId", metavar="Git-UserId");
-        optParser.add_option("--git-pswd", dest="git_pswd", default="", help="Git (authentication) Password", metavar="Git-Password");
+        optParser.add_option("--git-user", dest="git_user", default="", help="Git (authentication) UserId (not required if using 'BranchDirectory')", metavar="Git-UserId");
+        optParser.add_option("--git-pswd", dest="git_pswd", default="", help="Git (authentication) Password (not required if using 'BranchDirectory')", metavar="Git-Password");
      
         (options, args) = optParser.parse_args();
      

--- a/CxApplicationScanner1_README.md
+++ b/CxApplicationScanner1_README.md
@@ -12,37 +12,42 @@ This project is still in BETA and has not been officially released.
 
 --- How to setup to run the Tool ---
 
-1) Make sure that a version of Python 3 (v3.4+) is installed. You can download Python (for your OS) from: https://www.python.org/downloads/
-
-2) Make sure you have the latest version of 'pip'. From a 'elevated' (Admin) command prompt, 
-   run: python -m pip install pip
-
-3) Make sure you have the latest version of 'requests'. From a 'elevated' (Admin) command prompt, 
-   run: pip install requests
-
-4) Make sure you have the latest version of 'certifi'. From a 'elevated' (Admin) command prompt, 
-   run: pip install certifi
-
-6) Make sure you have the latest version of 'zope.interface'. From a 'elevated' (Admin) command prompt, 
-   run: pip install zope.interface
-
-5) Make sure you have the latest version of 'requests_toolbelt'. From a 'elevated' (Admin) command prompt, 
-   run: pip install requests_toolbelt
-
-7) On Windows:
-
-       a) The following 'extra' pip install commands may need to be issued:
-           pip install python-interface
-           pip install tqdm
-           pip install opencv-python
-
-8) Download the 'CxApplicationScanner1.zip' (zip) file and extract it to a subdirectory (on the Checkmarx POC/Manager machine).
-
-9) In a 'normal' command prompt, CD into the tool directory (containing the 'CxApplicationScanner1.py' file). 
-   Run: python CxApplicationScanner1.py --help 
+1. Make sure that a version of Python 3 (v3.4+) is installed. You can download Python (for your OS) from: https://www.python.org/downloads/
+2. Make sure you have the latest version of 'pip'. From a 'elevated' (Admin) command prompt, run:
+   ```bash
+   python -m pip install pip
+   ```
+3. Make sure you have the latest version of 'requests'. From a 'elevated' (Admin) command prompt, run:
+   ```bash
+   pip install requests
+   ```
+4. Make sure you have the latest version of 'certifi'. From a 'elevated' (Admin) command prompt, run:
+   ```bash
+   pip install certifi
+   ```
+5. Make sure you have the latest version of 'zope.interface'. From a 'elevated' (Admin) command prompt, run:
+   ```bash
+   pip install zope.interface
+   ```
+6. Make sure you have the latest version of 'requests_toolbelt'. From a 'elevated' (Admin) command prompt, run:
+   ```bash
+   pip install requests_toolbelt
+   ```
+7. On Windows:
+   * The following 'extra' pip install commands may need to be issued:
+      ```bash
+      pip install python-interface
+      pip install tqdm
+      pip install opencv-python
+      ```
+8. Download the 'CxApplicationScanner1.zip' (zip) file and extract it to a subdirectory (on the Checkmarx POC/Manager machine).
+9. In a 'normal' command prompt, CD into the tool directory (containing the 'CxApplicationScanner1.py' file) and run:
+   ```bash
+   python CxApplicationScanner1.py --help
+   ```
 
    This should display 'help' like the following:
-
+      ```bash
         CxApplicationScanner1.py (v1.0111): The Checkmarx Application 'scanner' via Rest API #1
         is starting execution from Server [DRCMBP3-4.local] on [2019/11/11 at 10:09:08] under Python [v3.7.3]...
 
@@ -71,36 +76,28 @@ This project is still in BETA and has not been officially released.
                                 Application 'work' directory [generated to - MUST be
                                 Empty]
           --git-user=Git-UserId
-                                Git (authentication) UserId
+                                Git (authentication) UserId (not required if using 'BranchDirectory')
           --git-pswd=Git-Password
-                                Git (authentication) Password
+                                Git (authentication) Password (not required if using 'BranchDirectory')
+      ```
 
 ## Extra Setup instructions
 
 --- Commands used by the Tool ---
 
-1) The tool requires the use of a 'zip' command:
-
-    a) For Windows, this is 7-zip: 
-
-       Install the '7z' command and make sure that it is in the PATH used by the command prompt.
-
-    b) For *Nix (Linux/Mac), this is the builtin 'zip' command.
-
-       Make sure that 'zip' can be issued in a command prompt and that the system finds the executable.
+1. The tool requires the use of a 'zip' command:
+   * For Windows, this is 7-zip. Install the '7z' command and make sure that it is in the PATH used by the command prompt.
+   * For *Nix (Linux/Mac), this is the builtin 'zip' command. Make sure that `zip` can be issued in a command prompt and that the system finds the executable.
 
 ## Operation
 
 --- How to run the Tool ---
 
-1) In order to have the 'plist' control file (required by CxApplicationScanner1.py) to provide it the 
-   'Application' information needed to create and scan a zip file, the tool 'CxTFSGetAllProjects1.py'
-   MUST have been run first to produce these control files (see 'CxTFSGetAllProjects1_README.md').
+1. In order to have the 'plist' control file (required by CxApplicationScanner1.py) to provide it the 'Application' information needed to create and scan a zip file, the tool 'CxTFSGetAllProjects1.py' MUST have been run first to produce these control files (see 'CxTFSGetAllProjects1_README.md').
 
-2) In a 'normal' command prompt, CD into the tool directory (containing the 'CxApplicationScanner1.py' file).
-   You MUST create an (empty) 'working' directory for the tool to generate the .zip file to be scanned.
-
-   Run: 
+2. In a 'normal' command prompt, CD into the tool directory (containing the 'CxApplicationScanner1.py' file). You MUST create an (empty) 'working' directory for the tool to generate the .zip file to be scanned.
+   Run:
+      ```bash
        python CxApplicationScanner1.py
        -v 
        --url protocol://<Checkmarx-hostname-or-IP>:<port#>
@@ -112,23 +109,25 @@ This project is still in BETA and has not been officially released.
        -w ./AppScanner_WorkDir 
        --git-user <name (Git)>
        --git-pswd <password (Git)>
-       > CxApplicationScanner1.ot1_10042019.log 2>&1 
+       > CxApplicationScanner1.ot1_10042019.log 2>&1
+      ```
 
-   Where: 
-       a) The command can all be on one line. It's broken out to separate lines here to make it easier to read.
-       c) The --url needs to be updated to point to your Checkmarx host (by DNS name or IP). Like 'https://192.168.2.190:8080'.
-       d) The --user is your Checkmarx User name (aka, ID).
-       e) The --pswd is your Checkmarx (User) password.
-       f) The -o is the output 'report' file to be generated.
-       g) The -d is an existing directory where the generated Project (App) 'plist' files were written out to.
-       h) The -p is the filename of the generated Project (App) 'plist' to be scanned.
-       i) The -w is an existing (empty) directory where the generated Project (App) zip file will be created.
-       j) The --git-user is your Git User name (aka, ID).
-       k) The --git-pswd is your Git (User) password.
+   Where:
+      1. The command can all be on one line. It's broken out to separate lines here to make it easier to read.
+      2. The --url needs to be updated to point to your Checkmarx host (by DNS name or IP). Like 'https://192.168.2.190:8080'.
+      3. The --user is your Checkmarx User name (aka, ID).
+      4. The --pswd is your Checkmarx (User) password.
+      5. The -o is the output 'report' file to be generated.
+      6. The -d is an existing directory where the generated Project (App) 'plist' files were written out to.
+      7. The -p is the filename of the generated Project (App) 'plist' to be scanned.
+      8. The -w is an existing (empty) directory where the generated Project (App) zip file will be created.
+      9. The --git-user is your Git User name (aka, ID).
+      10. The --git-pswd is your Git (User) password.
+
+   **Note: git credentials are not required if your plist file uses the `BranchDirectory` option in `RepoBranches` config. See [Sample_ProjectCreator_AppScanner-local-repo.plist](Sample_ProjectCreator_AppScanner-local-repo.plist) for an example.**
 
    Then:
-       a) Zip up and send back the files 'CxApplicationScanner1_report.txt' and 'CxApplicationScanner1.ot1_10042019.log' and
-          add all of the generated contents in the 'AppScanner_WorkDir' directory.
+      * Zip up and send back the files 'CxApplicationScanner1_report.txt' and 'CxApplicationScanner1.ot1_10042019.log' and add all of the generated contents in the 'AppScanner_WorkDir' directory.
 
 ## Future Enhancements
 

--- a/CxApplicationScannerGITZipper1.py
+++ b/CxApplicationScannerGITZipper1.py
@@ -496,6 +496,7 @@ class CxApplicationScannerGITZipper(object):
                     print("%s For a CxProjectCreation named [%s] type [%s] created an application repo 'target' directory of [%s]..." % (self.sClassDisp, sCxProjectName, sCxProjectZipTargetType, sAppRepoTargetDirspec));
 
                 sAppRepoBranch = None;
+                sAppRepoDirectory = None;
 
                 listAppRepoBranches = dictAppRepoItem["RepoBranches"];
 
@@ -536,17 +537,28 @@ class CxApplicationScannerGITZipper(object):
 
                         sAppRepoBranch = asAppRepoBranchTokens[2];
 
+                        if "BranchDirectory" in dictAppRepoBranch:
+                            sAppRepoDirectory = dictAppRepoBranch["BranchDirectory"];
+
                         break;
 
-                bCloneAppRepoBranchOk = self.__cloneCxAppRepoBranchToDirectory(appreporemoteurl=sAppRepoRemoteURL, apprepobranch=sAppRepoBranch, apprepotargetdir=sAppRepoTargetDirspec);
+                if sAppRepoDirectory != None and len(sAppRepoDirectory) > 0:
+                    if os.path.isdir(sAppRepoDirectory):
+                        print("%s Will use directory for source code instead of cloning: [%s]" % (self.sClassDisp, sAppRepoDirectory));
+                        self.__copyAppRepoDirectory(sourcedir=sAppRepoDirectory, destdir=sAppRepoTargetDirspec);
+                    else:
+                        print("%s Provided directory [%s] is not valid!" % (self.sClassDisp, sAppRepoDirectory));
+                        return False;
+                else:
 
-                if bCloneAppRepoBranchOk == False:
+                    bCloneAppRepoBranchOk = self.__cloneCxAppRepoBranchToDirectory(appreporemoteurl=sAppRepoRemoteURL, apprepobranch=sAppRepoBranch, apprepotargetdir=sAppRepoTargetDirspec);
 
-                    print("");
-                    print("%s '__cloneCxAppRepoBranchToDirectory()' API call failed - Error!" % (self.sClassDisp));
-                    print("");
+                    if bCloneAppRepoBranchOk == False:
+                        print("");
+                        print("%s '__cloneCxAppRepoBranchToDirectory()' API call failed - Error!" % (self.sClassDisp));
+                        print("");
 
-                    continue;
+                        continue;
 
             # Zip up the App Repo(s)...
 
@@ -592,6 +604,12 @@ class CxApplicationScannerGITZipper(object):
             return False;
 
         return True;
+
+    def __copyAppRepoDirectory(self, sourcedir=None, destdir=None):
+        if self.bTraceFlag == True:
+            print("%s Copying [%s] to [%s]" % (self.sClassDisp, sourcedir, destdir));
+        from distutils.dir_util import copy_tree;
+        copy_tree(sourcedir, destdir);
 
     def __cloneCxAppRepoBranchToDirectory(self, appreporemoteurl=None, apprepobranch=None, apprepotargetdir=None):
 

--- a/Sample_ProjectCreator_AppScanner-local-repo.plist
+++ b/Sample_ProjectCreator_AppScanner-local-repo.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AppGroupName</key>
+	<string>JWS_Dev</string>
+	<key>AppIsActive</key>
+	<string>true</string>
+	<key>AppName</key>
+	<string>JWS_App-Project_1</string>
+	<key>AppProjectId</key>
+	<string>0</string>
+	<key>AppIsPublic</key>
+	<string>true</string>
+	<key>AppScanIsPublic</key>
+	<string>true</string>
+	<key>AppScanType</key>
+	<string>both</string>
+    <key>AppCreateBranches</key>
+    <string>true</string>
+	<key>AppRepos</key>
+	<array>
+		<dict>
+			<key>RepoBranches</key>
+			<array>
+				<dict>
+					<key>BranchIsActive</key>
+					<string>true</string>
+					<key>BranchName</key>
+					<string>refs/heads/master</string>
+					<key>BranchDirectory</key>
+					<string>/path/to/local/repo</string>
+				</dict>
+			</array>
+			<key>RepoIsActive</key>
+			<string>true</string>
+			<key>RepoRemoteURL</key>
+			<string>http://10.211.55.50/jwebsoftwaredev/jws_app-project_gitlab_1.git</string>
+			<key>RepoSshURL</key>
+			<string>git@10.211.55.50:jwebsoftwaredev/jws_app-project_gitlab_1.git</string>
+			<key>RepoTitle</key>
+			<string>JWS_App-Project_GitLab_1</string>
+			<key>RepoURL</key>
+			<string>http://10.211.55.50/jwebsoftwaredev/jws_app-project_gitlab_1.git</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR adds support so that the application scanning utility will use a local repo directory for a branch as opposed to cloning the branch from a remote git server. This is useful in the case of a CI environment, where an automated job has already checked out the necessary source code to be scanned; in this scenario, another `git clone` is unnecessary. Using this option also allows the tool to run without needing to configure git access.

To use this feature, the plist for the app needs to have the new `BranchDirectory` key under the `RepoBranches` array:

```xml
<key>RepoBranches</key>
<array>
	<dict>
		...
		<key>BranchDirectory</key>
		<string>/path/to/local/repo</string>
	</dict>
</array>
```

If this option is set, no git credentials need to be provided from the command line:
```bash
python CxApplicationScanner1.py
-v
--url protocol://<Checkmarx-hostname-or-IP>:<port#>
--user <name (Checkmarx)>
--pswd <password (Checkmarx)>
-o CxApplicationScanner1_report.txt
-d Generated_App_Plists
-p "App-Project_1.plist"
-w ./AppScanner_WorkDir
> CxApplicationScanner1.ot1_10042019.log 2>&1
```

Also in this PR:
* added a sample plist with the new config.
* cleaned up markdown formatting for the application scanner.