### PR TITLE
Add scan creation detail

### DIFF
--- a/CxRestAPIProjectCreationBase1.py
+++ b/CxRestAPIProjectCreationBase1.py
@@ -2099,6 +2099,9 @@ class CxRestAPIProjectCreationBase:
                 #   cxProjectCreation.setCxProjectExtraField2(cxprojectextrafield2=dictCxScanData);
                 #   cxProjectCreation.setCxProjectId(cxprojectid=dictCxReqResponseJsonItem);
 
+            if "id" in dictCxReqResponseJson:
+                print("\n%s Scan [%s] created for project [%s]\n" % (self.sClassDisp, dictCxReqResponseJson["id"], cxProjectCreation.getCxProjectId()));
+
         except Exception as inst:
 
             print("%s 'scanCxRestAPIProject()' - exception occured..." % (self.sClassDisp));


### PR DESCRIPTION
This PR is a small change to log the newly created scan ID (and project it is associated with). This is helpful as it can easily be searched for (by automated tool or manual) to see what the resulting scan ID is.